### PR TITLE
Handle null hook pointers.

### DIFF
--- a/src/KeraLua/Lua.cs
+++ b/src/KeraLua/Lua.cs
@@ -332,7 +332,7 @@ namespace KeraLua
 
 		public static int LuaSetHook (IntPtr luaState, LuaHook func, int mask, int count)
 		{
-			IntPtr funcHook = Marshal.GetFunctionPointerForDelegate (func);
+			IntPtr funcHook = func == null ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate (func);
 			return NativeMethods.LuaSetHook (luaState, funcHook, mask, count);
 		}
 


### PR DESCRIPTION
NLua calls LuaSetHook with a null func pointer to clear the debug hook (and others may as well), but Marshal.GetFunctionPointerForDelegate does not allow this.
