### PR TITLE
Support AnyCPU

### DIFF
--- a/src/INativeMethods.cs
+++ b/src/INativeMethods.cs
@@ -1,0 +1,410 @@
+﻿
+using size_t = System.UIntPtr;
+using lua_State = System.IntPtr;
+using lua_CFunction = System.IntPtr;
+using voidptr_t = System.IntPtr;
+using charptr_t = System.IntPtr;
+using lua_KContext = System.IntPtr;
+using lua_KFunction = System.IntPtr;
+using lua_Writer = System.IntPtr;
+using lua_Reader = System.IntPtr;
+using lua_Alloc = System.IntPtr;
+using lua_Hook = System.IntPtr;
+using lua_Integer = System.Int64;
+using lua_Number = System.Double;
+using lua_Number_ptr = System.IntPtr;
+using lua_Debug = System.IntPtr;
+using System.Runtime.InteropServices;
+
+namespace KeraLua
+{
+    public interface INativeMethods
+    {
+
+        int lua_absindex(lua_State luaState, int idx);
+
+        void lua_arith(lua_State luaState, int op);
+
+        lua_CFunction lua_atpanic(lua_State luaState, lua_CFunction panicf);
+
+        
+        void lua_callk(lua_State luaState, int nargs, int nresults, lua_KContext ctx, lua_KFunction k);
+
+        
+        int lua_checkstack(lua_State luaState, int extra);
+
+        
+        void lua_close(lua_State luaState);
+
+        
+        int lua_compare(lua_State luaState, int index1, int index2, int op);
+
+        
+        void lua_concat(lua_State luaState, int n);
+
+        
+        void lua_copy(lua_State luaState, int fromIndex, int toIndex);
+
+        
+        void lua_createtable(lua_State luaState, int elements, int records);
+
+        
+        int lua_dump(lua_State luaState, lua_Writer writer, voidptr_t data, int strip);
+
+        
+        int lua_error(lua_State luaState);
+
+        
+        int lua_gc(lua_State luaState, int what, int data);
+
+        
+        lua_Alloc lua_getallocf(lua_State luaState, ref voidptr_t ud);
+
+        
+        int lua_getfield(lua_State luaState, int index, string k);
+
+        
+        int lua_getglobal(lua_State luaState, string name);
+
+        
+        lua_Hook lua_gethook(lua_State luaState);
+
+        
+        int lua_gethookcount(lua_State luaState);
+
+        
+        int lua_gethookmask(lua_State luaState);
+
+        
+        int lua_geti(lua_State luaState, int index, long i);
+
+        
+        int lua_getinfo(lua_State luaState, string what, lua_Debug ar);
+
+        
+        string lua_getlocal(lua_State luaState, lua_Debug ar, int n);
+
+        
+        int lua_getmetatable(lua_State luaState, int index);
+
+        
+        int lua_getstack(lua_State luaState, int level, lua_Debug n);
+
+        
+        int lua_gettable(lua_State luaState, int index);
+
+        
+        int lua_gettop(lua_State luaState);
+
+        
+        string lua_getupvalue(lua_State luaState, int funcIndex, int n);
+
+        
+        int lua_getuservalue(lua_State luaState, int index);
+
+        
+        int lua_iscfunction(lua_State luaState, int index);
+
+        
+        int lua_isinteger(lua_State luaState, int index);
+
+        
+        int lua_isnumber(lua_State luaState, int index);
+
+        
+        int lua_isstring(lua_State luaState, int index);
+
+        
+        int lua_isuserdata(lua_State luaState, int index);
+
+        
+        int lua_isyieldable(lua_State luaState);
+
+        
+        void lua_len(lua_State luaState, int index);
+
+        
+        int lua_load
+           (lua_State luaState,
+            lua_Reader reader,
+            voidptr_t data,
+            string chunkName,
+            string mode);
+
+        
+        lua_State lua_newstate(lua_Alloc allocFunction, voidptr_t ud);
+
+        
+        lua_State lua_newthread(lua_State luaState);
+
+        
+        voidptr_t lua_newuserdata(lua_State luaState, size_t size);
+
+        
+        int lua_next(lua_State luaState, int index);
+
+        
+        int lua_pcallk
+            (lua_State luaState,
+            int nargs,
+            int nresults,
+            int errorfunc,
+            lua_KContext ctx,
+            lua_KFunction k);
+
+        
+        void lua_pushboolean(lua_State luaState, int value);
+
+        
+        void lua_pushcclosure(lua_State luaState, lua_CFunction f, int n);
+
+        
+        void lua_pushinteger(lua_State luaState, lua_Integer n);
+
+        
+        void lua_pushlightuserdata(lua_State luaState, voidptr_t udata);
+
+        
+        charptr_t lua_pushlstring(lua_State luaState, byte[] s, size_t len);
+
+        
+        void lua_pushnil(lua_State luaState);
+
+        
+        void lua_pushnumber(lua_State luaState, lua_Number number);
+
+        
+        int lua_pushthread(lua_State luaState);
+
+        
+        void lua_pushvalue(lua_State luaState, int index);
+
+        
+        int lua_rawequal(lua_State luaState, int index1, int index2);
+
+        
+        int lua_rawget(lua_State luaState, int index);
+
+        
+        int lua_rawgeti(lua_State luaState, int index, lua_Integer n);
+
+        
+        int lua_rawgetp(lua_State luaState, int index, voidptr_t p);
+
+        
+        size_t lua_rawlen(lua_State luaState, int index);
+
+        
+        void lua_rawset(lua_State luaState, int index);
+
+        
+        void lua_rawseti(lua_State luaState, int index, lua_Integer i);
+
+        
+        void lua_rawsetp(lua_State luaState, int index, voidptr_t p);
+
+        
+        int lua_resume(lua_State luaState, lua_State from, int nargs);
+
+        
+        void lua_rotate(lua_State luaState, int index, int n);
+
+        
+        void lua_setallocf(lua_State luaState, lua_Alloc f, voidptr_t ud);
+
+        
+        void lua_setfield(lua_State luaState, int index, string key);
+
+        
+        void lua_setglobal(lua_State luaState, string key);
+
+        
+        void lua_sethook(lua_State luaState, lua_Hook f, int mask, int count);
+
+        
+        void lua_seti(lua_State luaState, int index, long n);
+
+        
+        string lua_setlocal(lua_State luaState, lua_Debug ar, int n);
+
+        
+        void lua_setmetatable(lua_State luaState, int objIndex);
+
+        
+        void lua_settable(lua_State luaState, int index);
+
+        
+        void lua_settop(lua_State luaState, int newTop);
+
+        
+        string lua_setupvalue(lua_State luaState, int funcIndex, int n);
+
+        
+        void lua_setuservalue(lua_State luaState, int index);
+
+        
+        int lua_status(lua_State luaState);
+
+        
+        size_t lua_stringtonumber(lua_State luaState, string s);
+
+        
+        int lua_toboolean(lua_State luaState, int index);
+
+        
+        lua_CFunction lua_tocfunction(lua_State luaState, int index);
+
+        
+        lua_Integer lua_tointegerx(lua_State luaState, int index, out int isNum);
+
+        
+        charptr_t lua_tolstring(lua_State luaState, int index, out size_t strLen);
+
+        
+        lua_Number lua_tonumberx(lua_State luaState, int index, out int isNum);
+
+        
+        voidptr_t lua_topointer(lua_State luaState, int index);
+
+        
+        lua_State lua_tothread(lua_State luaState, int index);
+
+        
+        voidptr_t lua_touserdata(lua_State luaState, int index);
+
+        
+        int lua_type(lua_State luaState, int index);
+
+        
+        string lua_typename(lua_State luaState, int type);
+
+        
+        voidptr_t lua_upvalueid(lua_State luaState, int funcIndex, int n);
+
+        
+        void lua_upvaluejoin(lua_State luaState, int funcIndex1, int n1, int funcIndex2, int n2);
+
+        
+        lua_Number_ptr lua_version(lua_State luaState);
+
+        
+        void lua_xmove(lua_State from, lua_State to, int n);
+
+        
+        int lua_yieldk(lua_State luaState,
+            int nresults,
+            lua_KContext ctx,
+            lua_KFunction k);
+
+        
+        int luaL_argerror(lua_State luaState, int arg, string message);
+
+        
+        int luaL_callmeta(lua_State luaState, int obj, string e);
+
+        
+        void luaL_checkany(lua_State luaState, int arg);
+
+        
+        lua_Integer luaL_checkinteger(lua_State luaState, int arg);
+
+        
+        charptr_t luaL_checklstring(lua_State luaState, int arg, out size_t len);
+
+        
+        lua_Number luaL_checknumber(lua_State luaState, int arg);
+
+        
+        int luaL_checkoption(lua_State luaState, int arg, string def, string[] list);
+
+        
+        void luaL_checkstack(lua_State luaState, int sz, string message);
+
+        
+        void luaL_checktype(lua_State luaState, int arg, int type);
+
+        
+        voidptr_t luaL_checkudata(lua_State luaState, int arg, string tName);
+
+
+        void luaL_checkversion_(lua_State luaState, lua_Number ver, size_t sz);
+
+
+        int luaL_error(lua_State luaState, string message);
+
+        
+        int luaL_execresult(lua_State luaState, int stat);
+
+        
+        int luaL_fileresult(lua_State luaState, int stat, string fileName);
+
+        
+        int luaL_getmetafield(lua_State luaState, int obj, string e);
+
+        
+        int luaL_getsubtable(lua_State luaState, int index, string name);
+
+        
+        lua_Integer luaL_len(lua_State luaState, int index);
+
+        
+        int luaL_loadbufferx
+            (lua_State luaState,
+            byte[] buff,
+            size_t sz,
+            string name,
+            string mode);
+
+        
+        int luaL_loadfilex(lua_State luaState, string name, string mode);
+
+        
+        int luaL_newmetatable(lua_State luaState, string name);
+
+        
+        lua_State luaL_newstate();
+
+        
+        void luaL_openlibs(lua_State luaState);
+
+        
+        lua_Integer luaL_optinteger(lua_State luaState, int arg, lua_Integer d);
+
+        
+        lua_Number luaL_optnumber(lua_State luaState, int arg, lua_Number d);
+
+        
+        int luaL_ref(lua_State luaState, int registryIndex);
+
+        
+        void luaL_requiref(lua_State luaState, string moduleName, lua_CFunction openFunction, int global);
+
+        
+        void luaL_setfuncs(lua_State luaState, [In] LuaRegister[] luaReg, int numUp);
+
+        
+        void luaL_setmetatable(lua_State luaState, string tName);
+
+        
+        voidptr_t luaL_testudata(lua_State luaState, int arg, string tName);
+
+        
+        charptr_t luaL_tolstring(lua_State luaState, int index, out size_t len);
+
+        
+        charptr_t luaL_traceback
+           (lua_State luaState,
+            lua_State luaState2,
+            string message,
+            int level);
+
+        
+        string luaL_typename(lua_State luaState, int index);
+
+        
+        void luaL_unref(lua_State luaState, int registryIndex, int reference);
+
+        
+        void luaL_where(lua_State luaState, int level);
+    }
+}

--- a/src/KeraLua.Core.projitems
+++ b/src/KeraLua.Core.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>KeraLua</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)INativeMethods.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LuaHookMask.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DelegateExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Delegates.cs" />
@@ -22,7 +23,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)LuaRegistry.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LuaStatus.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LuaType.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NativeMethods64.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NativeMethods.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NativeMethodsImpl64.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NativeMethodsImpl.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Properties\AssemblyInfo.cs" />
   </ItemGroup>
 </Project>

--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -9,6 +9,26 @@ namespace KeraLua
     /// </summary>
     public class Lua : IDisposable
     {
+        private static INativeMethods NativeMethods;
+
+        static Lua()
+        {
+            if (IntPtr.Size == 4)
+            {
+                // 32-bit
+                NativeMethods = new NativeMethodsImpl();
+            }
+            else if (IntPtr.Size == 8)
+            {
+                // 64-bit
+                NativeMethods = new NativeMethodsImpl64();
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
+
         private IntPtr _luaState;
         private readonly Lua _mainState;
 

--- a/src/NativeMethods64.cs
+++ b/src/NativeMethods64.cs
@@ -1,0 +1,437 @@
+﻿// ReSharper disable IdentifierTypo
+using System.Runtime.InteropServices;
+using System.Security;
+
+using size_t = System.UIntPtr;
+using lua_State = System.IntPtr;
+using lua_CFunction = System.IntPtr;
+using voidptr_t = System.IntPtr;
+using charptr_t = System.IntPtr;
+using lua_KContext = System.IntPtr;
+using lua_KFunction = System.IntPtr;
+using lua_Writer = System.IntPtr;
+using lua_Reader = System.IntPtr;
+using lua_Alloc = System.IntPtr;
+using lua_Hook = System.IntPtr;
+using lua_Integer = System.Int64;
+using lua_Number = System.Double;
+using lua_Number_ptr = System.IntPtr;
+using lua_Debug = System.IntPtr;
+
+namespace KeraLua
+{
+    [SuppressUnmanagedCodeSecurity]
+    internal static class NativeMethods64
+    {
+
+#if __TVOS__ && __UNIFIED__
+        private const string LuaLibraryName = "@rpath/liblua53.framework/liblua53";
+#elif __WATCHOS__ && __UNIFIED__
+        private const string LuaLibraryName = "@rpath/liblua53.framework/liblua53";
+#elif __IOS__ && __UNIFIED__
+        private const string LuaLibraryName = "@rpath/liblua53.framework/liblua53";
+#elif __ANDROID__
+        private const string LuaLibraryName = "liblua53.so";
+#elif __MACOS__ 
+        private const string LuaLibraryName = "liblua53.dylib";
+#elif WINDOWS_UWP
+        private const string LuaLibraryName = "lua53_64.dll";
+#else
+        private const string LuaLibraryName = "lua53_64.dll";
+#endif
+
+#pragma warning disable IDE1006 // Naming Styles
+
+        [DllImport (LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_absindex(lua_State luaState, int idx);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_arith(lua_State luaState, int op);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern lua_CFunction lua_atpanic(lua_State luaState, lua_CFunction panicf);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_callk(lua_State luaState, int nargs, int nresults, lua_KContext ctx, lua_KFunction k);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_checkstack(lua_State luaState, int extra);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_close(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_compare(lua_State luaState, int index1, int index2, int op);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_concat(lua_State luaState, int n);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_copy(lua_State luaState, int fromIndex, int toIndex);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_createtable(lua_State luaState, int elements, int records);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_dump(lua_State luaState, lua_Writer writer, voidptr_t data, int strip);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_error(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_gc(lua_State luaState, int what, int data);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern lua_Alloc lua_getallocf(lua_State luaState, ref voidptr_t ud);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern int lua_getfield(lua_State luaState, int index, string k);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern int lua_getglobal(lua_State luaState, string name);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern lua_Hook lua_gethook(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_gethookcount(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_gethookmask(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_geti(lua_State luaState, int index, long i);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern int lua_getinfo(lua_State luaState, string what, lua_Debug ar);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern string lua_getlocal(lua_State luaState, lua_Debug ar, int n);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_getmetatable(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_getstack(lua_State luaState, int level, lua_Debug n);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_gettable(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_gettop(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern string lua_getupvalue(lua_State luaState, int funcIndex, int n);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_getuservalue(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_iscfunction(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_isinteger(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_isnumber(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_isstring(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_isuserdata(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_isyieldable(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_len(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern int lua_load
+           (lua_State luaState,
+            lua_Reader reader,
+            voidptr_t data,
+            string chunkName,
+            string mode);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern lua_State lua_newstate(lua_Alloc allocFunction, voidptr_t ud);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern lua_State lua_newthread(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern voidptr_t lua_newuserdata(lua_State luaState, size_t size);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_next(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_pcallk
+            (lua_State luaState,
+            int nargs,
+            int nresults,
+            int errorfunc,
+            lua_KContext ctx,
+            lua_KFunction k);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_pushboolean(lua_State luaState, int value);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_pushcclosure(lua_State luaState, lua_CFunction f, int n);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_pushinteger(lua_State luaState, lua_Integer n);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_pushlightuserdata(lua_State luaState, voidptr_t udata);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern charptr_t lua_pushlstring(lua_State luaState, byte [] s, size_t len);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_pushnil(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_pushnumber(lua_State luaState, lua_Number number);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_pushthread(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_pushvalue(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_rawequal(lua_State luaState, int index1, int index2);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_rawget(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_rawgeti(lua_State luaState, int index, lua_Integer n);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_rawgetp(lua_State luaState, int index, voidptr_t p);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern size_t lua_rawlen(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_rawset(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_rawseti(lua_State luaState, int index, lua_Integer i);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_rawsetp(lua_State luaState, int index, voidptr_t p);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_resume(lua_State luaState, lua_State from, int nargs);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_rotate(lua_State luaState, int index, int n);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_setallocf(lua_State luaState, lua_Alloc f, voidptr_t ud);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern void lua_setfield(lua_State luaState, int index, string key);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern void lua_setglobal(lua_State luaState, string key);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_sethook(lua_State luaState, lua_Hook f, int mask, int count);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_seti(lua_State luaState, int index, long n);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern string lua_setlocal(lua_State luaState, lua_Debug ar, int n);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_setmetatable(lua_State luaState, int objIndex);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_settable(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_settop(lua_State luaState, int newTop);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern string lua_setupvalue(lua_State luaState, int funcIndex, int n);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_setuservalue(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_status(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern size_t lua_stringtonumber(lua_State luaState, string s);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_toboolean(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern lua_CFunction lua_tocfunction(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern lua_Integer lua_tointegerx(lua_State luaState, int index, out int isNum);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern charptr_t lua_tolstring(lua_State luaState, int index, out size_t strLen);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern lua_Number lua_tonumberx(lua_State luaState, int index, out int isNum);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern voidptr_t lua_topointer(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern lua_State lua_tothread(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern voidptr_t lua_touserdata(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_type(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern string lua_typename(lua_State luaState, int type);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern voidptr_t lua_upvalueid(lua_State luaState, int funcIndex, int n);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_upvaluejoin(lua_State luaState, int funcIndex1, int n1, int funcIndex2, int n2);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern lua_Number_ptr lua_version(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void lua_xmove(lua_State from, lua_State to, int n);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int lua_yieldk(lua_State luaState,
+            int nresults,
+            lua_KContext ctx,
+            lua_KFunction k);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern int luaL_argerror(lua_State luaState, int arg, string message);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern int luaL_callmeta(lua_State luaState, int obj, string e);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void luaL_checkany(lua_State luaState, int arg);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern lua_Integer luaL_checkinteger(lua_State luaState, int arg);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern charptr_t luaL_checklstring(lua_State luaState, int arg, out size_t len);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern lua_Number luaL_checknumber(lua_State luaState, int arg);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern int luaL_checkoption(lua_State luaState, int arg, string def, string [] list);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern void luaL_checkstack(lua_State luaState, int sz, string message);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void luaL_checktype(lua_State luaState, int arg, int type);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern voidptr_t luaL_checkudata(lua_State luaState, int arg, string tName);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern void luaL_checkversion_(lua_State luaState, lua_Number ver, size_t sz);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern int luaL_error(lua_State luaState, string message);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int luaL_execresult(lua_State luaState, int stat);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern int luaL_fileresult(lua_State luaState, int stat, string fileName);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern int luaL_getmetafield(lua_State luaState, int obj, string e);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern int luaL_getsubtable(lua_State luaState, int index, string name);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern lua_Integer luaL_len(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern int luaL_loadbufferx
+            (lua_State luaState,
+            byte[] buff,
+            size_t sz,
+            string name,
+            string mode);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern int luaL_loadfilex(lua_State luaState, string name, string mode);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern int luaL_newmetatable(lua_State luaState, string name);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern lua_State luaL_newstate();
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void luaL_openlibs(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern lua_Integer luaL_optinteger(lua_State luaState, int arg, lua_Integer d);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern lua_Number luaL_optnumber(lua_State luaState, int arg, lua_Number d);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int luaL_ref(lua_State luaState, int registryIndex);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern void luaL_requiref(lua_State luaState, string moduleName, lua_CFunction openFunction, int global);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void luaL_setfuncs(lua_State luaState, [In] LuaRegister [] luaReg, int numUp);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern void luaL_setmetatable(lua_State luaState, string tName);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern voidptr_t luaL_testudata(lua_State luaState, int arg, string tName);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern charptr_t luaL_tolstring(lua_State luaState, int index, out size_t len);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern charptr_t luaL_traceback
+           (lua_State luaState,
+            lua_State luaState2,
+            string message,
+            int level);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern string luaL_typename(lua_State luaState, int index);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void luaL_unref(lua_State luaState, int registryIndex, int reference);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void luaL_where(lua_State luaState, int level);
+
+#pragma warning restore IDE1006 // Naming Styles
+
+    }
+}

--- a/src/NativeMethodsImpl.cs
+++ b/src/NativeMethodsImpl.cs
@@ -1,0 +1,623 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace KeraLua
+{
+    public class NativeMethodsImpl : INativeMethods
+    {
+        public System.Int32 luaL_loadbufferx(System.IntPtr luaState, System.Byte[] buff, System.UIntPtr sz, System.String name, System.String mode)
+        {
+            return NativeMethods.luaL_loadbufferx(luaState, buff, sz, name, mode);
+        }
+
+        public System.Int32 luaL_loadfilex(System.IntPtr luaState, System.String name, System.String mode)
+        {
+            return NativeMethods.luaL_loadfilex(luaState, name, mode);
+        }
+
+        public System.Int32 luaL_newmetatable(System.IntPtr luaState, System.String name)
+        {
+            return NativeMethods.luaL_newmetatable(luaState, name);
+        }
+
+        public System.IntPtr luaL_newstate()
+        {
+            return NativeMethods.luaL_newstate();
+        }
+
+        public void luaL_openlibs(System.IntPtr luaState)
+        {
+            NativeMethods.luaL_openlibs(luaState);
+        }
+
+        public System.Int64 luaL_optinteger(System.IntPtr luaState, System.Int32 arg, System.Int64 d)
+        {
+            return NativeMethods.luaL_optinteger(luaState, arg, d);
+        }
+
+        public System.Double luaL_optnumber(System.IntPtr luaState, System.Int32 arg, System.Double d)
+        {
+            return NativeMethods.luaL_optnumber(luaState, arg, d);
+        }
+
+        public System.Int32 luaL_ref(System.IntPtr luaState, System.Int32 registryIndex)
+        {
+            return NativeMethods.luaL_ref(luaState, registryIndex);
+        }
+
+        public void luaL_requiref(System.IntPtr luaState, System.String moduleName, System.IntPtr openFunction, System.Int32 global)
+        {
+            NativeMethods.luaL_requiref(luaState, moduleName, openFunction, global);
+        }
+
+        public void luaL_setfuncs(System.IntPtr luaState, KeraLua.LuaRegister[] luaReg, System.Int32 numUp)
+        {
+            NativeMethods.luaL_setfuncs(luaState, luaReg, numUp);
+        }
+
+        public void luaL_setmetatable(System.IntPtr luaState, System.String tName)
+        {
+            NativeMethods.luaL_setmetatable(luaState, tName);
+        }
+
+        public System.IntPtr luaL_testudata(System.IntPtr luaState, System.Int32 arg, System.String tName)
+        {
+            return NativeMethods.luaL_testudata(luaState, arg, tName);
+        }
+
+        public System.IntPtr luaL_tolstring(System.IntPtr luaState, System.Int32 index, out System.UIntPtr len)
+        {
+            return NativeMethods.luaL_tolstring(luaState, index, out len);
+        }
+
+        public System.IntPtr luaL_traceback(System.IntPtr luaState, System.IntPtr luaState2, System.String message, System.Int32 level)
+        {
+            return NativeMethods.luaL_traceback(luaState, luaState2, message, level);
+        }
+
+        public System.String luaL_typename(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.luaL_typename(luaState, index);
+        }
+
+        public void luaL_unref(System.IntPtr luaState, System.Int32 registryIndex, System.Int32 reference)
+        {
+            NativeMethods.luaL_unref(luaState, registryIndex, reference);
+        }
+
+        public void luaL_where(System.IntPtr luaState, System.Int32 level)
+        {
+            NativeMethods.luaL_where(luaState, level);
+        }
+
+        public void lua_upvaluejoin(System.IntPtr luaState, System.Int32 funcIndex1, System.Int32 n1, System.Int32 funcIndex2, System.Int32 n2)
+        {
+            NativeMethods.lua_upvaluejoin(luaState, funcIndex1, n1, funcIndex2, n2);
+        }
+
+        public System.IntPtr lua_version(System.IntPtr luaState)
+        {
+            return NativeMethods.lua_version(luaState);
+        }
+
+        public void lua_xmove(System.IntPtr from, System.IntPtr to, System.Int32 n)
+        {
+            NativeMethods.lua_xmove(from, to, n);
+        }
+
+        public System.Int32 lua_yieldk(System.IntPtr luaState, System.Int32 nresults, System.IntPtr ctx, System.IntPtr k)
+        {
+            return NativeMethods.lua_yieldk(luaState, nresults, ctx, k);
+        }
+
+        public System.Int32 luaL_argerror(System.IntPtr luaState, System.Int32 arg, System.String message)
+        {
+            return NativeMethods.luaL_argerror(luaState, arg, message);
+        }
+
+        public System.Int32 luaL_callmeta(System.IntPtr luaState, System.Int32 obj, System.String e)
+        {
+            return NativeMethods.luaL_callmeta(luaState, obj, e);
+        }
+
+        public void luaL_checkany(System.IntPtr luaState, System.Int32 arg)
+        {
+            NativeMethods.luaL_checkany(luaState, arg);
+        }
+
+        public System.Int64 luaL_checkinteger(System.IntPtr luaState, System.Int32 arg)
+        {
+            return NativeMethods.luaL_checkinteger(luaState, arg);
+        }
+
+        public System.IntPtr luaL_checklstring(System.IntPtr luaState, System.Int32 arg, out System.UIntPtr len)
+        {
+            return NativeMethods.luaL_checklstring(luaState, arg, out len);
+        }
+
+        public System.Double luaL_checknumber(System.IntPtr luaState, System.Int32 arg)
+        {
+            return NativeMethods.luaL_checknumber(luaState, arg);
+        }
+
+        public System.Int32 luaL_checkoption(System.IntPtr luaState, System.Int32 arg, System.String def, System.String[] list)
+        {
+            return NativeMethods.luaL_checkoption(luaState, arg, def, list);
+        }
+
+        public void luaL_checkstack(System.IntPtr luaState, System.Int32 sz, System.String message)
+        {
+            NativeMethods.luaL_checkstack(luaState, sz, message);
+        }
+
+        public void luaL_checktype(System.IntPtr luaState, System.Int32 arg, System.Int32 type)
+        {
+            NativeMethods.luaL_checktype(luaState, arg, type);
+        }
+
+        public System.IntPtr luaL_checkudata(System.IntPtr luaState, System.Int32 arg, System.String tName)
+        {
+            return NativeMethods.luaL_checkudata(luaState, arg, tName);
+        }
+
+        public void luaL_checkversion_(System.IntPtr luaState, System.Double ver, System.UIntPtr sz)
+        {
+            NativeMethods.luaL_checkversion_(luaState, ver, sz);
+        }
+
+        public System.Int32 luaL_error(System.IntPtr luaState, System.String message)
+        {
+            return NativeMethods.luaL_error(luaState, message);
+        }
+
+        public System.Int32 luaL_execresult(System.IntPtr luaState, System.Int32 stat)
+        {
+            return NativeMethods.luaL_execresult(luaState, stat);
+        }
+
+        public System.Int32 luaL_fileresult(System.IntPtr luaState, System.Int32 stat, System.String fileName)
+        {
+            return NativeMethods.luaL_fileresult(luaState, stat, fileName);
+        }
+
+        public System.Int32 luaL_getmetafield(System.IntPtr luaState, System.Int32 obj, System.String e)
+        {
+            return NativeMethods.luaL_getmetafield(luaState, obj, e);
+        }
+
+        public System.Int32 luaL_getsubtable(System.IntPtr luaState, System.Int32 index, System.String name)
+        {
+            return NativeMethods.luaL_getsubtable(luaState, index, name);
+        }
+
+        public System.Int64 luaL_len(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.luaL_len(luaState, index);
+        }
+
+        public void lua_sethook(System.IntPtr luaState, System.IntPtr f, System.Int32 mask, System.Int32 count)
+        {
+            NativeMethods.lua_sethook(luaState, f, mask, count);
+        }
+
+        public void lua_seti(System.IntPtr luaState, System.Int32 index, System.Int64 n)
+        {
+            NativeMethods.lua_seti(luaState, index, n);
+        }
+
+        public System.String lua_setlocal(System.IntPtr luaState, System.IntPtr ar, System.Int32 n)
+        {
+            return NativeMethods.lua_setlocal(luaState, ar, n);
+        }
+
+        public void lua_setmetatable(System.IntPtr luaState, System.Int32 objIndex)
+        {
+            NativeMethods.lua_setmetatable(luaState, objIndex);
+        }
+
+        public void lua_settable(System.IntPtr luaState, System.Int32 index)
+        {
+            NativeMethods.lua_settable(luaState, index);
+        }
+
+        public void lua_settop(System.IntPtr luaState, System.Int32 newTop)
+        {
+            NativeMethods.lua_settop(luaState, newTop);
+        }
+
+        public System.String lua_setupvalue(System.IntPtr luaState, System.Int32 funcIndex, System.Int32 n)
+        {
+            return NativeMethods.lua_setupvalue(luaState, funcIndex, n);
+        }
+
+        public void lua_setuservalue(System.IntPtr luaState, System.Int32 index)
+        {
+            NativeMethods.lua_setuservalue(luaState, index);
+        }
+
+        public System.Int32 lua_status(System.IntPtr luaState)
+        {
+            return NativeMethods.lua_status(luaState);
+        }
+
+        public System.UIntPtr lua_stringtonumber(System.IntPtr luaState, System.String s)
+        {
+            return NativeMethods.lua_stringtonumber(luaState, s);
+        }
+
+        public System.Int32 lua_toboolean(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.lua_toboolean(luaState, index);
+        }
+
+        public System.IntPtr lua_tocfunction(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.lua_tocfunction(luaState, index);
+        }
+
+        public System.Int64 lua_tointegerx(System.IntPtr luaState, System.Int32 index, out System.Int32 isNum)
+        {
+            return NativeMethods.lua_tointegerx(luaState, index, out isNum);
+        }
+
+        public System.IntPtr lua_tolstring(System.IntPtr luaState, System.Int32 index, out System.UIntPtr strLen)
+        {
+            return NativeMethods.lua_tolstring(luaState, index, out strLen);
+        }
+
+        public System.Double lua_tonumberx(System.IntPtr luaState, System.Int32 index, out System.Int32 isNum)
+        {
+            return NativeMethods.lua_tonumberx(luaState, index, out isNum);
+        }
+
+        public System.IntPtr lua_topointer(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.lua_topointer(luaState, index);
+        }
+
+        public System.IntPtr lua_tothread(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.lua_tothread(luaState, index);
+        }
+
+        public System.IntPtr lua_touserdata(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.lua_touserdata(luaState, index);
+        }
+
+        public System.Int32 lua_type(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.lua_type(luaState, index);
+        }
+
+        public System.String lua_typename(System.IntPtr luaState, System.Int32 type)
+        {
+            return NativeMethods.lua_typename(luaState, type);
+        }
+
+        public System.IntPtr lua_upvalueid(System.IntPtr luaState, System.Int32 funcIndex, System.Int32 n)
+        {
+            return NativeMethods.lua_upvalueid(luaState, funcIndex, n);
+        }
+
+        public void lua_pushcclosure(System.IntPtr luaState, System.IntPtr f, System.Int32 n)
+        {
+            NativeMethods.lua_pushcclosure(luaState, f, n);
+        }
+
+        public void lua_pushinteger(System.IntPtr luaState, System.Int64 n)
+        {
+            NativeMethods.lua_pushinteger(luaState, n);
+        }
+
+        public void lua_pushlightuserdata(System.IntPtr luaState, System.IntPtr udata)
+        {
+            NativeMethods.lua_pushlightuserdata(luaState, udata);
+        }
+
+        public System.IntPtr lua_pushlstring(System.IntPtr luaState, System.Byte[] s, System.UIntPtr len)
+        {
+            return NativeMethods.lua_pushlstring(luaState, s, len);
+        }
+
+        public void lua_pushnil(System.IntPtr luaState)
+        {
+            NativeMethods.lua_pushnil(luaState);
+        }
+
+        public void lua_pushnumber(System.IntPtr luaState, System.Double number)
+        {
+            NativeMethods.lua_pushnumber(luaState, number);
+        }
+
+        public System.Int32 lua_pushthread(System.IntPtr luaState)
+        {
+            return NativeMethods.lua_pushthread(luaState);
+        }
+
+        public void lua_pushvalue(System.IntPtr luaState, System.Int32 index)
+        {
+            NativeMethods.lua_pushvalue(luaState, index);
+        }
+
+        public System.Int32 lua_rawequal(System.IntPtr luaState, System.Int32 index1, System.Int32 index2)
+        {
+            return NativeMethods.lua_rawequal(luaState, index1, index2);
+        }
+
+        public System.Int32 lua_rawget(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.lua_rawget(luaState, index);
+        }
+
+        public System.Int32 lua_rawgeti(System.IntPtr luaState, System.Int32 index, System.Int64 n)
+        {
+            return NativeMethods.lua_rawgeti(luaState, index, n);
+        }
+
+        public System.Int32 lua_rawgetp(System.IntPtr luaState, System.Int32 index, System.IntPtr p)
+        {
+            return NativeMethods.lua_rawgetp(luaState, index, p);
+        }
+
+        public System.UIntPtr lua_rawlen(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.lua_rawlen(luaState, index);
+        }
+
+        public void lua_rawset(System.IntPtr luaState, System.Int32 index)
+        {
+            NativeMethods.lua_rawset(luaState, index);
+        }
+
+        public void lua_rawseti(System.IntPtr luaState, System.Int32 index, System.Int64 i)
+        {
+            NativeMethods.lua_rawseti(luaState, index, i);
+        }
+
+        public void lua_rawsetp(System.IntPtr luaState, System.Int32 index, System.IntPtr p)
+        {
+            NativeMethods.lua_rawsetp(luaState, index, p);
+        }
+
+        public System.Int32 lua_resume(System.IntPtr luaState, System.IntPtr from, System.Int32 nargs)
+        {
+            return NativeMethods.lua_resume(luaState, from, nargs);
+        }
+
+        public void lua_rotate(System.IntPtr luaState, System.Int32 index, System.Int32 n)
+        {
+            NativeMethods.lua_rotate(luaState, index, n);
+        }
+
+        public void lua_setallocf(System.IntPtr luaState, System.IntPtr f, System.IntPtr ud)
+        {
+            NativeMethods.lua_setallocf(luaState, f, ud);
+        }
+
+        public void lua_setfield(System.IntPtr luaState, System.Int32 index, System.String key)
+        {
+            NativeMethods.lua_setfield(luaState, index, key);
+        }
+
+        public void lua_setglobal(System.IntPtr luaState, System.String key)
+        {
+            NativeMethods.lua_setglobal(luaState, key);
+        }
+
+        public System.String lua_getlocal(System.IntPtr luaState, System.IntPtr ar, System.Int32 n)
+        {
+            return NativeMethods.lua_getlocal(luaState, ar, n);
+        }
+
+        public System.Int32 lua_getmetatable(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.lua_getmetatable(luaState, index);
+        }
+
+        public System.Int32 lua_getstack(System.IntPtr luaState, System.Int32 level, System.IntPtr n)
+        {
+            return NativeMethods.lua_getstack(luaState, level, n);
+        }
+
+        public System.Int32 lua_gettable(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.lua_gettable(luaState, index);
+        }
+
+        public System.Int32 lua_gettop(System.IntPtr luaState)
+        {
+            return NativeMethods.lua_gettop(luaState);
+        }
+
+        public System.String lua_getupvalue(System.IntPtr luaState, System.Int32 funcIndex, System.Int32 n)
+        {
+            return NativeMethods.lua_getupvalue(luaState, funcIndex, n);
+        }
+
+        public System.Int32 lua_getuservalue(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.lua_getuservalue(luaState, index);
+        }
+
+        public System.Int32 lua_iscfunction(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.lua_iscfunction(luaState, index);
+        }
+
+        public System.Int32 lua_isinteger(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.lua_isinteger(luaState, index);
+        }
+
+        public System.Int32 lua_isnumber(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.lua_isnumber(luaState, index);
+        }
+
+        public System.Int32 lua_isstring(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.lua_isstring(luaState, index);
+        }
+
+        public System.Int32 lua_isuserdata(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.lua_isuserdata(luaState, index);
+        }
+
+        public System.Int32 lua_isyieldable(System.IntPtr luaState)
+        {
+            return NativeMethods.lua_isyieldable(luaState);
+        }
+
+        public void lua_len(System.IntPtr luaState, System.Int32 index)
+        {
+            NativeMethods.lua_len(luaState, index);
+        }
+
+        public System.Int32 lua_load(System.IntPtr luaState, System.IntPtr reader, System.IntPtr data, System.String chunkName, System.String mode)
+        {
+            return NativeMethods.lua_load(luaState, reader, data, chunkName, mode);
+        }
+
+        public System.IntPtr lua_newstate(System.IntPtr allocFunction, System.IntPtr ud)
+        {
+            return NativeMethods.lua_newstate(allocFunction, ud);
+        }
+
+        public System.IntPtr lua_newthread(System.IntPtr luaState)
+        {
+            return NativeMethods.lua_newthread(luaState);
+        }
+
+        public System.IntPtr lua_newuserdata(System.IntPtr luaState, System.UIntPtr size)
+        {
+            return NativeMethods.lua_newuserdata(luaState, size);
+        }
+
+        public System.Int32 lua_next(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods.lua_next(luaState, index);
+        }
+
+        public System.Int32 lua_pcallk(System.IntPtr luaState, System.Int32 nargs, System.Int32 nresults, System.Int32 errorfunc, System.IntPtr ctx, System.IntPtr k)
+        {
+            return NativeMethods.lua_pcallk(luaState, nargs, nresults, errorfunc, ctx, k);
+        }
+
+        public void lua_pushboolean(System.IntPtr luaState, System.Int32 value)
+        {
+            NativeMethods.lua_pushboolean(luaState, value);
+        }
+
+        public System.Int32 lua_absindex(System.IntPtr luaState, System.Int32 idx)
+        {
+            return NativeMethods.lua_absindex(luaState, idx);
+        }
+
+        public void lua_arith(System.IntPtr luaState, System.Int32 op)
+        {
+            NativeMethods.lua_arith(luaState, op);
+        }
+
+        public System.IntPtr lua_atpanic(System.IntPtr luaState, System.IntPtr panicf)
+        {
+            return NativeMethods.lua_atpanic(luaState, panicf);
+        }
+
+        public void lua_callk(System.IntPtr luaState, System.Int32 nargs, System.Int32 nresults, System.IntPtr ctx, System.IntPtr k)
+        {
+            NativeMethods.lua_callk(luaState, nargs, nresults, ctx, k);
+        }
+
+        public System.Int32 lua_checkstack(System.IntPtr luaState, System.Int32 extra)
+        {
+            return NativeMethods.lua_checkstack(luaState, extra);
+        }
+
+        public void lua_close(System.IntPtr luaState)
+        {
+            NativeMethods.lua_close(luaState);
+        }
+
+        public System.Int32 lua_compare(System.IntPtr luaState, System.Int32 index1, System.Int32 index2, System.Int32 op)
+        {
+            return NativeMethods.lua_compare(luaState, index1, index2, op);
+        }
+
+        public void lua_concat(System.IntPtr luaState, System.Int32 n)
+        {
+            NativeMethods.lua_concat(luaState, n);
+        }
+
+        public void lua_copy(System.IntPtr luaState, System.Int32 fromIndex, System.Int32 toIndex)
+        {
+            NativeMethods.lua_copy(luaState, fromIndex, toIndex);
+        }
+
+        public void lua_createtable(System.IntPtr luaState, System.Int32 elements, System.Int32 records)
+        {
+            NativeMethods.lua_createtable(luaState, elements, records);
+        }
+
+        public System.Int32 lua_dump(System.IntPtr luaState, System.IntPtr writer, System.IntPtr data, System.Int32 strip)
+        {
+            return NativeMethods.lua_dump(luaState, writer, data, strip);
+        }
+
+        public System.Int32 lua_error(System.IntPtr luaState)
+        {
+            return NativeMethods.lua_error(luaState);
+        }
+
+        public System.Int32 lua_gc(System.IntPtr luaState, System.Int32 what, System.Int32 data)
+        {
+            return NativeMethods.lua_gc(luaState, what, data);
+        }
+
+        public System.IntPtr lua_getallocf(System.IntPtr luaState, ref System.IntPtr ud)
+        {
+            return NativeMethods.lua_getallocf(luaState, ref ud);
+        }
+
+        public System.Int32 lua_getfield(System.IntPtr luaState, System.Int32 index, System.String k)
+        {
+            return NativeMethods.lua_getfield(luaState, index, k);
+        }
+
+        public System.Int32 lua_getglobal(System.IntPtr luaState, System.String name)
+        {
+            return NativeMethods.lua_getglobal(luaState, name);
+        }
+
+        public System.IntPtr lua_gethook(System.IntPtr luaState)
+        {
+            return NativeMethods.lua_gethook(luaState);
+        }
+
+        public System.Int32 lua_gethookcount(System.IntPtr luaState)
+        {
+            return NativeMethods.lua_gethookcount(luaState);
+        }
+
+        public System.Int32 lua_gethookmask(System.IntPtr luaState)
+        {
+            return NativeMethods.lua_gethookmask(luaState);
+        }
+
+        public System.Int32 lua_geti(System.IntPtr luaState, System.Int32 index, System.Int64 i)
+        {
+            return NativeMethods.lua_geti(luaState, index, i);
+        }
+
+        public System.Int32 lua_getinfo(System.IntPtr luaState, System.String what, System.IntPtr ar)
+        {
+            return NativeMethods.lua_getinfo(luaState, what, ar);
+        }
+
+
+    }
+}

--- a/src/NativeMethodsImpl64.cs
+++ b/src/NativeMethodsImpl64.cs
@@ -1,0 +1,623 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace KeraLua
+{
+    public class NativeMethodsImpl64 : INativeMethods
+    {
+        public System.Int32 luaL_loadbufferx(System.IntPtr luaState, System.Byte[] buff, System.UIntPtr sz, System.String name, System.String mode)
+        {
+            return NativeMethods64.luaL_loadbufferx(luaState, buff, sz, name, mode);
+        }
+
+        public System.Int32 luaL_loadfilex(System.IntPtr luaState, System.String name, System.String mode)
+        {
+            return NativeMethods64.luaL_loadfilex(luaState, name, mode);
+        }
+
+        public System.Int32 luaL_newmetatable(System.IntPtr luaState, System.String name)
+        {
+            return NativeMethods64.luaL_newmetatable(luaState, name);
+        }
+
+        public System.IntPtr luaL_newstate()
+        {
+            return NativeMethods64.luaL_newstate();
+        }
+
+        public void luaL_openlibs(System.IntPtr luaState)
+        {
+            NativeMethods64.luaL_openlibs(luaState);
+        }
+
+        public System.Int64 luaL_optinteger(System.IntPtr luaState, System.Int32 arg, System.Int64 d)
+        {
+            return NativeMethods64.luaL_optinteger(luaState, arg, d);
+        }
+
+        public System.Double luaL_optnumber(System.IntPtr luaState, System.Int32 arg, System.Double d)
+        {
+            return NativeMethods64.luaL_optnumber(luaState, arg, d);
+        }
+
+        public System.Int32 luaL_ref(System.IntPtr luaState, System.Int32 registryIndex)
+        {
+            return NativeMethods64.luaL_ref(luaState, registryIndex);
+        }
+
+        public void luaL_requiref(System.IntPtr luaState, System.String moduleName, System.IntPtr openFunction, System.Int32 global)
+        {
+            NativeMethods64.luaL_requiref(luaState, moduleName, openFunction, global);
+        }
+
+        public void luaL_setfuncs(System.IntPtr luaState, KeraLua.LuaRegister[] luaReg, System.Int32 numUp)
+        {
+            NativeMethods64.luaL_setfuncs(luaState, luaReg, numUp);
+        }
+
+        public void luaL_setmetatable(System.IntPtr luaState, System.String tName)
+        {
+            NativeMethods64.luaL_setmetatable(luaState, tName);
+        }
+
+        public System.IntPtr luaL_testudata(System.IntPtr luaState, System.Int32 arg, System.String tName)
+        {
+            return NativeMethods64.luaL_testudata(luaState, arg, tName);
+        }
+
+        public System.IntPtr luaL_tolstring(System.IntPtr luaState, System.Int32 index, out System.UIntPtr len)
+        {
+            return NativeMethods64.luaL_tolstring(luaState, index, out len);
+        }
+
+        public System.IntPtr luaL_traceback(System.IntPtr luaState, System.IntPtr luaState2, System.String message, System.Int32 level)
+        {
+            return NativeMethods64.luaL_traceback(luaState, luaState2, message, level);
+        }
+
+        public System.String luaL_typename(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.luaL_typename(luaState, index);
+        }
+
+        public void luaL_unref(System.IntPtr luaState, System.Int32 registryIndex, System.Int32 reference)
+        {
+            NativeMethods64.luaL_unref(luaState, registryIndex, reference);
+        }
+
+        public void luaL_where(System.IntPtr luaState, System.Int32 level)
+        {
+            NativeMethods64.luaL_where(luaState, level);
+        }
+
+        public void lua_upvaluejoin(System.IntPtr luaState, System.Int32 funcIndex1, System.Int32 n1, System.Int32 funcIndex2, System.Int32 n2)
+        {
+            NativeMethods64.lua_upvaluejoin(luaState, funcIndex1, n1, funcIndex2, n2);
+        }
+
+        public System.IntPtr lua_version(System.IntPtr luaState)
+        {
+            return NativeMethods64.lua_version(luaState);
+        }
+
+        public void lua_xmove(System.IntPtr from, System.IntPtr to, System.Int32 n)
+        {
+            NativeMethods64.lua_xmove(from, to, n);
+        }
+
+        public System.Int32 lua_yieldk(System.IntPtr luaState, System.Int32 nresults, System.IntPtr ctx, System.IntPtr k)
+        {
+            return NativeMethods64.lua_yieldk(luaState, nresults, ctx, k);
+        }
+
+        public System.Int32 luaL_argerror(System.IntPtr luaState, System.Int32 arg, System.String message)
+        {
+            return NativeMethods64.luaL_argerror(luaState, arg, message);
+        }
+
+        public System.Int32 luaL_callmeta(System.IntPtr luaState, System.Int32 obj, System.String e)
+        {
+            return NativeMethods64.luaL_callmeta(luaState, obj, e);
+        }
+
+        public void luaL_checkany(System.IntPtr luaState, System.Int32 arg)
+        {
+            NativeMethods64.luaL_checkany(luaState, arg);
+        }
+
+        public System.Int64 luaL_checkinteger(System.IntPtr luaState, System.Int32 arg)
+        {
+            return NativeMethods64.luaL_checkinteger(luaState, arg);
+        }
+
+        public System.IntPtr luaL_checklstring(System.IntPtr luaState, System.Int32 arg, out System.UIntPtr len)
+        {
+            return NativeMethods64.luaL_checklstring(luaState, arg, out len);
+        }
+
+        public System.Double luaL_checknumber(System.IntPtr luaState, System.Int32 arg)
+        {
+            return NativeMethods64.luaL_checknumber(luaState, arg);
+        }
+
+        public System.Int32 luaL_checkoption(System.IntPtr luaState, System.Int32 arg, System.String def, System.String[] list)
+        {
+            return NativeMethods64.luaL_checkoption(luaState, arg, def, list);
+        }
+
+        public void luaL_checkstack(System.IntPtr luaState, System.Int32 sz, System.String message)
+        {
+            NativeMethods64.luaL_checkstack(luaState, sz, message);
+        }
+
+        public void luaL_checktype(System.IntPtr luaState, System.Int32 arg, System.Int32 type)
+        {
+            NativeMethods64.luaL_checktype(luaState, arg, type);
+        }
+
+        public System.IntPtr luaL_checkudata(System.IntPtr luaState, System.Int32 arg, System.String tName)
+        {
+            return NativeMethods64.luaL_checkudata(luaState, arg, tName);
+        }
+
+        public void luaL_checkversion_(System.IntPtr luaState, System.Double ver, System.UIntPtr sz)
+        {
+            NativeMethods64.luaL_checkversion_(luaState, ver, sz);
+        }
+
+        public System.Int32 luaL_error(System.IntPtr luaState, System.String message)
+        {
+            return NativeMethods64.luaL_error(luaState, message);
+        }
+
+        public System.Int32 luaL_execresult(System.IntPtr luaState, System.Int32 stat)
+        {
+            return NativeMethods64.luaL_execresult(luaState, stat);
+        }
+
+        public System.Int32 luaL_fileresult(System.IntPtr luaState, System.Int32 stat, System.String fileName)
+        {
+            return NativeMethods64.luaL_fileresult(luaState, stat, fileName);
+        }
+
+        public System.Int32 luaL_getmetafield(System.IntPtr luaState, System.Int32 obj, System.String e)
+        {
+            return NativeMethods64.luaL_getmetafield(luaState, obj, e);
+        }
+
+        public System.Int32 luaL_getsubtable(System.IntPtr luaState, System.Int32 index, System.String name)
+        {
+            return NativeMethods64.luaL_getsubtable(luaState, index, name);
+        }
+
+        public System.Int64 luaL_len(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.luaL_len(luaState, index);
+        }
+
+        public void lua_sethook(System.IntPtr luaState, System.IntPtr f, System.Int32 mask, System.Int32 count)
+        {
+            NativeMethods64.lua_sethook(luaState, f, mask, count);
+        }
+
+        public void lua_seti(System.IntPtr luaState, System.Int32 index, System.Int64 n)
+        {
+            NativeMethods64.lua_seti(luaState, index, n);
+        }
+
+        public System.String lua_setlocal(System.IntPtr luaState, System.IntPtr ar, System.Int32 n)
+        {
+            return NativeMethods64.lua_setlocal(luaState, ar, n);
+        }
+
+        public void lua_setmetatable(System.IntPtr luaState, System.Int32 objIndex)
+        {
+            NativeMethods64.lua_setmetatable(luaState, objIndex);
+        }
+
+        public void lua_settable(System.IntPtr luaState, System.Int32 index)
+        {
+            NativeMethods64.lua_settable(luaState, index);
+        }
+
+        public void lua_settop(System.IntPtr luaState, System.Int32 newTop)
+        {
+            NativeMethods64.lua_settop(luaState, newTop);
+        }
+
+        public System.String lua_setupvalue(System.IntPtr luaState, System.Int32 funcIndex, System.Int32 n)
+        {
+            return NativeMethods64.lua_setupvalue(luaState, funcIndex, n);
+        }
+
+        public void lua_setuservalue(System.IntPtr luaState, System.Int32 index)
+        {
+            NativeMethods64.lua_setuservalue(luaState, index);
+        }
+
+        public System.Int32 lua_status(System.IntPtr luaState)
+        {
+            return NativeMethods64.lua_status(luaState);
+        }
+
+        public System.UIntPtr lua_stringtonumber(System.IntPtr luaState, System.String s)
+        {
+            return NativeMethods64.lua_stringtonumber(luaState, s);
+        }
+
+        public System.Int32 lua_toboolean(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.lua_toboolean(luaState, index);
+        }
+
+        public System.IntPtr lua_tocfunction(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.lua_tocfunction(luaState, index);
+        }
+
+        public System.Int64 lua_tointegerx(System.IntPtr luaState, System.Int32 index, out System.Int32 isNum)
+        {
+            return NativeMethods64.lua_tointegerx(luaState, index, out isNum);
+        }
+
+        public System.IntPtr lua_tolstring(System.IntPtr luaState, System.Int32 index, out System.UIntPtr strLen)
+        {
+            return NativeMethods64.lua_tolstring(luaState, index, out strLen);
+        }
+
+        public System.Double lua_tonumberx(System.IntPtr luaState, System.Int32 index, out System.Int32 isNum)
+        {
+            return NativeMethods64.lua_tonumberx(luaState, index, out isNum);
+        }
+
+        public System.IntPtr lua_topointer(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.lua_topointer(luaState, index);
+        }
+
+        public System.IntPtr lua_tothread(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.lua_tothread(luaState, index);
+        }
+
+        public System.IntPtr lua_touserdata(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.lua_touserdata(luaState, index);
+        }
+
+        public System.Int32 lua_type(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.lua_type(luaState, index);
+        }
+
+        public System.String lua_typename(System.IntPtr luaState, System.Int32 type)
+        {
+            return NativeMethods64.lua_typename(luaState, type);
+        }
+
+        public System.IntPtr lua_upvalueid(System.IntPtr luaState, System.Int32 funcIndex, System.Int32 n)
+        {
+            return NativeMethods64.lua_upvalueid(luaState, funcIndex, n);
+        }
+
+        public void lua_pushcclosure(System.IntPtr luaState, System.IntPtr f, System.Int32 n)
+        {
+            NativeMethods64.lua_pushcclosure(luaState, f, n);
+        }
+
+        public void lua_pushinteger(System.IntPtr luaState, System.Int64 n)
+        {
+            NativeMethods64.lua_pushinteger(luaState, n);
+        }
+
+        public void lua_pushlightuserdata(System.IntPtr luaState, System.IntPtr udata)
+        {
+            NativeMethods64.lua_pushlightuserdata(luaState, udata);
+        }
+
+        public System.IntPtr lua_pushlstring(System.IntPtr luaState, System.Byte[] s, System.UIntPtr len)
+        {
+            return NativeMethods64.lua_pushlstring(luaState, s, len);
+        }
+
+        public void lua_pushnil(System.IntPtr luaState)
+        {
+            NativeMethods64.lua_pushnil(luaState);
+        }
+
+        public void lua_pushnumber(System.IntPtr luaState, System.Double number)
+        {
+            NativeMethods64.lua_pushnumber(luaState, number);
+        }
+
+        public System.Int32 lua_pushthread(System.IntPtr luaState)
+        {
+            return NativeMethods64.lua_pushthread(luaState);
+        }
+
+        public void lua_pushvalue(System.IntPtr luaState, System.Int32 index)
+        {
+            NativeMethods64.lua_pushvalue(luaState, index);
+        }
+
+        public System.Int32 lua_rawequal(System.IntPtr luaState, System.Int32 index1, System.Int32 index2)
+        {
+            return NativeMethods64.lua_rawequal(luaState, index1, index2);
+        }
+
+        public System.Int32 lua_rawget(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.lua_rawget(luaState, index);
+        }
+
+        public System.Int32 lua_rawgeti(System.IntPtr luaState, System.Int32 index, System.Int64 n)
+        {
+            return NativeMethods64.lua_rawgeti(luaState, index, n);
+        }
+
+        public System.Int32 lua_rawgetp(System.IntPtr luaState, System.Int32 index, System.IntPtr p)
+        {
+            return NativeMethods64.lua_rawgetp(luaState, index, p);
+        }
+
+        public System.UIntPtr lua_rawlen(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.lua_rawlen(luaState, index);
+        }
+
+        public void lua_rawset(System.IntPtr luaState, System.Int32 index)
+        {
+            NativeMethods64.lua_rawset(luaState, index);
+        }
+
+        public void lua_rawseti(System.IntPtr luaState, System.Int32 index, System.Int64 i)
+        {
+            NativeMethods64.lua_rawseti(luaState, index, i);
+        }
+
+        public void lua_rawsetp(System.IntPtr luaState, System.Int32 index, System.IntPtr p)
+        {
+            NativeMethods64.lua_rawsetp(luaState, index, p);
+        }
+
+        public System.Int32 lua_resume(System.IntPtr luaState, System.IntPtr from, System.Int32 nargs)
+        {
+            return NativeMethods64.lua_resume(luaState, from, nargs);
+        }
+
+        public void lua_rotate(System.IntPtr luaState, System.Int32 index, System.Int32 n)
+        {
+            NativeMethods64.lua_rotate(luaState, index, n);
+        }
+
+        public void lua_setallocf(System.IntPtr luaState, System.IntPtr f, System.IntPtr ud)
+        {
+            NativeMethods64.lua_setallocf(luaState, f, ud);
+        }
+
+        public void lua_setfield(System.IntPtr luaState, System.Int32 index, System.String key)
+        {
+            NativeMethods64.lua_setfield(luaState, index, key);
+        }
+
+        public void lua_setglobal(System.IntPtr luaState, System.String key)
+        {
+            NativeMethods64.lua_setglobal(luaState, key);
+        }
+
+        public System.String lua_getlocal(System.IntPtr luaState, System.IntPtr ar, System.Int32 n)
+        {
+            return NativeMethods64.lua_getlocal(luaState, ar, n);
+        }
+
+        public System.Int32 lua_getmetatable(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.lua_getmetatable(luaState, index);
+        }
+
+        public System.Int32 lua_getstack(System.IntPtr luaState, System.Int32 level, System.IntPtr n)
+        {
+            return NativeMethods64.lua_getstack(luaState, level, n);
+        }
+
+        public System.Int32 lua_gettable(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.lua_gettable(luaState, index);
+        }
+
+        public System.Int32 lua_gettop(System.IntPtr luaState)
+        {
+            return NativeMethods64.lua_gettop(luaState);
+        }
+
+        public System.String lua_getupvalue(System.IntPtr luaState, System.Int32 funcIndex, System.Int32 n)
+        {
+            return NativeMethods64.lua_getupvalue(luaState, funcIndex, n);
+        }
+
+        public System.Int32 lua_getuservalue(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.lua_getuservalue(luaState, index);
+        }
+
+        public System.Int32 lua_iscfunction(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.lua_iscfunction(luaState, index);
+        }
+
+        public System.Int32 lua_isinteger(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.lua_isinteger(luaState, index);
+        }
+
+        public System.Int32 lua_isnumber(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.lua_isnumber(luaState, index);
+        }
+
+        public System.Int32 lua_isstring(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.lua_isstring(luaState, index);
+        }
+
+        public System.Int32 lua_isuserdata(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.lua_isuserdata(luaState, index);
+        }
+
+        public System.Int32 lua_isyieldable(System.IntPtr luaState)
+        {
+            return NativeMethods64.lua_isyieldable(luaState);
+        }
+
+        public void lua_len(System.IntPtr luaState, System.Int32 index)
+        {
+            NativeMethods64.lua_len(luaState, index);
+        }
+
+        public System.Int32 lua_load(System.IntPtr luaState, System.IntPtr reader, System.IntPtr data, System.String chunkName, System.String mode)
+        {
+            return NativeMethods64.lua_load(luaState, reader, data, chunkName, mode);
+        }
+
+        public System.IntPtr lua_newstate(System.IntPtr allocFunction, System.IntPtr ud)
+        {
+            return NativeMethods64.lua_newstate(allocFunction, ud);
+        }
+
+        public System.IntPtr lua_newthread(System.IntPtr luaState)
+        {
+            return NativeMethods64.lua_newthread(luaState);
+        }
+
+        public System.IntPtr lua_newuserdata(System.IntPtr luaState, System.UIntPtr size)
+        {
+            return NativeMethods64.lua_newuserdata(luaState, size);
+        }
+
+        public System.Int32 lua_next(System.IntPtr luaState, System.Int32 index)
+        {
+            return NativeMethods64.lua_next(luaState, index);
+        }
+
+        public System.Int32 lua_pcallk(System.IntPtr luaState, System.Int32 nargs, System.Int32 nresults, System.Int32 errorfunc, System.IntPtr ctx, System.IntPtr k)
+        {
+            return NativeMethods64.lua_pcallk(luaState, nargs, nresults, errorfunc, ctx, k);
+        }
+
+        public void lua_pushboolean(System.IntPtr luaState, System.Int32 value)
+        {
+            NativeMethods64.lua_pushboolean(luaState, value);
+        }
+
+        public System.Int32 lua_absindex(System.IntPtr luaState, System.Int32 idx)
+        {
+            return NativeMethods64.lua_absindex(luaState, idx);
+        }
+
+        public void lua_arith(System.IntPtr luaState, System.Int32 op)
+        {
+            NativeMethods64.lua_arith(luaState, op);
+        }
+
+        public System.IntPtr lua_atpanic(System.IntPtr luaState, System.IntPtr panicf)
+        {
+            return NativeMethods64.lua_atpanic(luaState, panicf);
+        }
+
+        public void lua_callk(System.IntPtr luaState, System.Int32 nargs, System.Int32 nresults, System.IntPtr ctx, System.IntPtr k)
+        {
+            NativeMethods64.lua_callk(luaState, nargs, nresults, ctx, k);
+        }
+
+        public System.Int32 lua_checkstack(System.IntPtr luaState, System.Int32 extra)
+        {
+            return NativeMethods64.lua_checkstack(luaState, extra);
+        }
+
+        public void lua_close(System.IntPtr luaState)
+        {
+            NativeMethods64.lua_close(luaState);
+        }
+
+        public System.Int32 lua_compare(System.IntPtr luaState, System.Int32 index1, System.Int32 index2, System.Int32 op)
+        {
+            return NativeMethods64.lua_compare(luaState, index1, index2, op);
+        }
+
+        public void lua_concat(System.IntPtr luaState, System.Int32 n)
+        {
+            NativeMethods64.lua_concat(luaState, n);
+        }
+
+        public void lua_copy(System.IntPtr luaState, System.Int32 fromIndex, System.Int32 toIndex)
+        {
+            NativeMethods64.lua_copy(luaState, fromIndex, toIndex);
+        }
+
+        public void lua_createtable(System.IntPtr luaState, System.Int32 elements, System.Int32 records)
+        {
+            NativeMethods64.lua_createtable(luaState, elements, records);
+        }
+
+        public System.Int32 lua_dump(System.IntPtr luaState, System.IntPtr writer, System.IntPtr data, System.Int32 strip)
+        {
+            return NativeMethods64.lua_dump(luaState, writer, data, strip);
+        }
+
+        public System.Int32 lua_error(System.IntPtr luaState)
+        {
+            return NativeMethods64.lua_error(luaState);
+        }
+
+        public System.Int32 lua_gc(System.IntPtr luaState, System.Int32 what, System.Int32 data)
+        {
+            return NativeMethods64.lua_gc(luaState, what, data);
+        }
+
+        public System.IntPtr lua_getallocf(System.IntPtr luaState, ref System.IntPtr ud)
+        {
+            return NativeMethods64.lua_getallocf(luaState, ref ud);
+        }
+
+        public System.Int32 lua_getfield(System.IntPtr luaState, System.Int32 index, System.String k)
+        {
+            return NativeMethods64.lua_getfield(luaState, index, k);
+        }
+
+        public System.Int32 lua_getglobal(System.IntPtr luaState, System.String name)
+        {
+            return NativeMethods64.lua_getglobal(luaState, name);
+        }
+
+        public System.IntPtr lua_gethook(System.IntPtr luaState)
+        {
+            return NativeMethods64.lua_gethook(luaState);
+        }
+
+        public System.Int32 lua_gethookcount(System.IntPtr luaState)
+        {
+            return NativeMethods64.lua_gethookcount(luaState);
+        }
+
+        public System.Int32 lua_gethookmask(System.IntPtr luaState)
+        {
+            return NativeMethods64.lua_gethookmask(luaState);
+        }
+
+        public System.Int32 lua_geti(System.IntPtr luaState, System.Int32 index, System.Int64 i)
+        {
+            return NativeMethods64.lua_geti(luaState, index, i);
+        }
+
+        public System.Int32 lua_getinfo(System.IntPtr luaState, System.String what, System.IntPtr ar)
+        {
+            return NativeMethods64.lua_getinfo(luaState, what, ar);
+        }
+
+
+    }
+}


### PR DESCRIPTION
Contains changes to Support dynamic binding on 32 or 64 bit lua implementation depending on the currently running process. Changes only for windows platform. (Implementation only tested on windows, the 32 bit dll name is lua53.dll and for 64 bit processes lua53_64.dll) This behaviour can be changed in NativeMethods.cs (for 32 bit) and NativeMethods64.cs (for 64 bit)