### PR TITLE
Upvalue crash

### DIFF
--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -496,7 +496,27 @@ namespace KeraLua
         /// <param name="functionIndex"></param>
         /// <param name="n"></param>
         /// <returns>Returns the type of the pushed value. </returns>
-        public string GetUpValue(int functionIndex, int n) => NativeMethods.lua_getupvalue(_luaState, functionIndex, n);
+        public string GetUpValue(int functionIndex, int n) => MarshalString(NativeMethods.lua_getupvalue(_luaState, functionIndex, n));
+
+        /// <summary>
+        /// Converts a char* to a string, in a way that doesn't corrupt memory in specific circumstances
+        /// </summary>
+        /// <param name="ptr"></param>
+        /// <returns>The string</returns>
+        private string MarshalString(IntPtr ptr)
+        {
+            if (ptr == IntPtr.Zero)
+                return null;
+
+            if (Encoding == Encoding.ASCII)
+            {
+                return Marshal.PtrToStringAnsi(ptr);
+            }
+            else
+            {
+                return Marshal.PtrToStringUni(ptr);
+            }
+        }
 
         /// <summary>
         /// Returns the current hook function. 
@@ -1182,7 +1202,7 @@ namespace KeraLua
         /// <returns>Returns NULL (and pops nothing) when the index n is greater than the number of upvalues. </returns>
         public string SetUpValue(int functionIndex, int n)
         {
-            return NativeMethods.lua_setupvalue(_luaState, functionIndex, n);
+            return MarshalString(NativeMethods.lua_setupvalue(_luaState, functionIndex, n));
         }
 
         /// <summary>

--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -508,14 +508,7 @@ namespace KeraLua
             if (ptr == IntPtr.Zero)
                 return null;
 
-            if (Encoding == Encoding.ASCII)
-            {
-                return Marshal.PtrToStringAnsi(ptr);
-            }
-            else
-            {
-                return Marshal.PtrToStringUni(ptr);
-            }
+            return Marshal.PtrToStringAnsi(ptr);
         }
 
         /// <summary>

--- a/src/NativeMethods.cs
+++ b/src/NativeMethods.cs
@@ -121,7 +121,7 @@ namespace KeraLua
         internal static extern int lua_gettop(lua_State luaState);
 
         [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-        internal static extern string lua_getupvalue(lua_State luaState, int funcIndex, int n);
+        internal static extern charptr_t lua_getupvalue(lua_State luaState, int funcIndex, int n);
 
         [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int lua_getuservalue(lua_State luaState, int index);
@@ -261,7 +261,7 @@ namespace KeraLua
         internal static extern void lua_settop(lua_State luaState, int newTop);
 
         [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-        internal static extern string lua_setupvalue(lua_State luaState, int funcIndex, int n);
+        internal static extern charptr_t lua_setupvalue(lua_State luaState, int funcIndex, int n);
 
         [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void lua_setuservalue(lua_State luaState, int index);

--- a/tests/Tests/Interop.cs
+++ b/tests/Tests/Interop.cs
@@ -371,5 +371,32 @@ main.lua:11 (main)
                 Assert.AreEqual(currentTop, newTop, "#1.2");
             }
         }
+
+        [Test]
+        public void SettingUpValueDoesntCrash()
+        {
+            //This test should always pass. If it doesn't, it brings the test suite down.....
+            using (var lua = new Lua())
+            {
+                lua.LoadString("hello = 1");
+                lua.NewTable();
+                var result = lua.SetUpValue(-2, 1);
+
+                Assert.AreEqual("_ENV", result);
+            }
+        }
+
+        [Test]
+        public void GettingUpValueDoesntCrash()
+        {
+            //This test should always pass. If it doesn't, it brings the test suite down.....
+            using (var lua = new Lua())
+            {
+                lua.LoadString("hello = 1");
+                var result = lua.GetUpValue(-1, 1);
+
+                Assert.AreEqual("_ENV", result);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes the Lua.GetUpValue and Lua.SetUpValue functions to not crash the CLR when specific strings are returned.

I'm not 100% sure on the correctness of this method, however. I'm not sure who is responsible for strings that would have gotten freed before (without a crash), but aren't now. I'm also not 100% sure it matters, though.