### PR TITLE
Lua.Resume is documented as accepting null, but throws if you try

### DIFF
--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -1055,7 +1055,7 @@ namespace KeraLua
         /// <returns></returns>
         public LuaStatus Resume(Lua from, int arguments)
         {
-            return (LuaStatus)NativeMethods.lua_resume(_luaState, from._luaState, arguments);
+            return (LuaStatus)NativeMethods.lua_resume(_luaState, from?._luaState ?? IntPtr.Zero, arguments);
         }
 
         /// <summary>

--- a/tests/Tests/Interop.cs
+++ b/tests/Tests/Interop.cs
@@ -408,5 +408,17 @@ main.lua:11 (main)
                 Assert.AreEqual("_ENV", result, "#1");
             }
         }
+
+        [Test]
+        public void ResumeAcceptsNull()
+        {
+            using (var lua = new Lua())
+            {
+                lua.LoadString("hello = 1");
+                LuaStatus result = lua.Resume(null, 0);
+
+                Assert.AreEqual(LuaStatus.OK, result);
+            }
+        }
     }
 }


### PR DESCRIPTION
> The parameter from represents the coroutine that is resuming L.
> If there is no such coroutine, this parameter can be NULL. 

According to lua_resume and the documentation for Lua.Resume, you can pass NULL as the first parameter. However, KeraLua always tries to dereference that parameter, in order to grab the handle to pass to lua_resume. This results in a NullReferenceException.

This patch fixes this, and correctly resolves a null Lua object to IntPtr.Zero.