### PR TITLE
Fix typo in the MSBuild README command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Building
 ---------
 
 	nuget restore KeraLua.sln
-	msbuild KaraLua.sln
+	msbuild KeraLua.sln
 
 
 


### PR DESCRIPTION
Just noticed it says "`KaraLua.sln`" instead of "`KeraLua.sln`" in the README, this PR fixes that.