### PR TITLE
Add methods to individually open standard libraries.

### DIFF
--- a/src/KeraLua.Core.projitems
+++ b/src/KeraLua.Core.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>KeraLua</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)LuaLibraryName.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LuaHookMask.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DelegateExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Delegates.cs" />

--- a/src/Lua.cs
+++ b/src/Lua.cs
@@ -2014,6 +2014,106 @@ namespace KeraLua
         }
 
         /// <summary>
+        /// Open the standard base library into the given state.
+        /// </summary>
+        /// <param name="moduleName"></param>
+        /// <param name="global"></param>
+        public void OpenBase(string moduleName = LuaLibraryName.Base, bool global = true)
+        {
+            RequireF(moduleName, NativeMethods.luaopen_base, global);
+        }
+
+        /// <summary>
+        /// Open the standard package library into the given state.
+        /// </summary>
+        /// <param name="moduleName"></param>
+        /// <param name="global"></param>
+        public void OpenPackage(string moduleName = LuaLibraryName.Package, bool global = true)
+        {
+            RequireF(moduleName, NativeMethods.luaopen_package, global);
+        }
+
+        /// <summary>
+        /// Open the standard coroutine library into the given state.
+        /// </summary>
+        /// <param name="moduleName"></param>
+        /// <param name="global"></param>
+        public void OpenCoroutine(string moduleName = LuaLibraryName.Coroutine, bool global = true)
+        {
+            RequireF(moduleName, NativeMethods.luaopen_coroutine, global);
+        }
+
+        /// <summary>
+        /// Open the standard table library into the given state.
+        /// </summary>
+        /// <param name="moduleName"></param>
+        /// <param name="global"></param>
+        public void OpenTable(string moduleName = LuaLibraryName.Table, bool global = true)
+        {
+            RequireF(moduleName, NativeMethods.luaopen_table, global);
+        }
+
+        /// <summary>
+        /// Open the standard IO library into the given state.
+        /// </summary>
+        /// <param name="moduleName"></param>
+        /// <param name="global"></param>
+        public void OpenIO(string moduleName = LuaLibraryName.IO, bool global = true)
+        {
+            RequireF(moduleName, NativeMethods.luaopen_io, global);
+        }
+
+        /// <summary>
+        /// Open the standard OS library into the given state.
+        /// </summary>
+        /// <param name="moduleName"></param>
+        /// <param name="global"></param>
+        public void OpenOS(string moduleName = LuaLibraryName.OS, bool global = true)
+        {
+            RequireF(moduleName, NativeMethods.luaopen_os, global);
+        }
+
+        /// <summary>
+        /// Open the standard string library into the given state.
+        /// </summary>
+        /// <param name="moduleName"></param>
+        /// <param name="global"></param>
+        public void OpenString(string moduleName = LuaLibraryName.String, bool global = true)
+        {
+            RequireF(moduleName, NativeMethods.luaopen_string, global);
+        }
+
+        /// <summary>
+        /// Open the standard math library into the given state.
+        /// </summary>
+        /// <param name="moduleName"></param>
+        /// <param name="global"></param>
+        public void OpenMath(string moduleName = LuaLibraryName.Math, bool global = true)
+        {
+            RequireF(moduleName, NativeMethods.luaopen_math, global);
+        }
+
+        /// <summary>
+        /// Open the standard UTF8 library into the given state.
+        /// </summary>
+        /// <param name="moduleName"></param>
+        /// <param name="global"></param>
+        public void OpenUTF8(string moduleName = LuaLibraryName.UTF8, bool global = true)
+        {
+            RequireF(moduleName, NativeMethods.luaopen_utf8, global);
+        }
+
+        /// <summary>
+        /// Open the standard debug library into the given state.
+        /// </summary>
+        /// <param name="moduleName"></param>
+        /// <param name="global"></param>
+        public void OpenDebug(string moduleName = LuaLibraryName.Debug, bool global = true)
+        {
+            RequireF(moduleName, NativeMethods.luaopen_debug, global);
+        }
+
+        /// <summary>
         /// If the function argument arg is an integer (or convertible to an integer), returns this integer. If this argument is absent or is nil, returns d
         /// </summary>
         /// <param name="argument"></param>

--- a/src/LuaLibraryName.cs
+++ b/src/LuaLibraryName.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace KeraLua
+{
+    /// <summary>
+    /// Lua library names
+    /// </summary>
+    public static class LuaLibraryName
+    {
+        public const string Base = "_G";
+        public const string Package = "package";
+        public const string Coroutine = "coroutine";
+        public const string Table = "table";
+        public const string IO = "io";
+        public const string OS = "os";
+        public const string String = "string";
+        public const string Math = "math";
+        public const string UTF8 = "utf8";
+        public const string Debug = "debug";
+    }
+}

--- a/src/NativeMethods.cs
+++ b/src/NativeMethods.cs
@@ -331,6 +331,36 @@ namespace KeraLua
             lua_KContext ctx,
             lua_KFunction k);
 
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int luaopen_base(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int luaopen_package(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int luaopen_coroutine(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int luaopen_table(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int luaopen_io(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int luaopen_os(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int luaopen_string(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int luaopen_math(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int luaopen_utf8(lua_State luaState);
+
+        [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int luaopen_debug(lua_State luaState);
+
         [DllImport(LuaLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
         internal static extern int luaL_argerror(lua_State luaState, int arg, string message);
 


### PR DESCRIPTION
This PR adds all individual methods to open the standard libraries:

- `OpenBase` (_G)
- `OpenPackage`
- `OpenCoroutine`
- `OpenTable`
- `OpenIO`
- `OpenOS`
- `OpenString`
- `OpenMath`
- `OpenUTF8`
- `OpenDebug`

I could not make it build on my machine (both before and after the addition), so it would be nice to have it verified by someone more capable than me.