### PR TITLE
Add Linux/aarch64 (ARM64) build

### DIFF
--- a/KeraLua.nuspec
+++ b/KeraLua.nuspec
@@ -81,6 +81,7 @@
     <file src="runtimes\win-arm64\native\lua54.dll" target="runtimes\win-arm64\native\lua54.dll" />
     <file src="runtimes\osx\native\liblua54.dylib" target="runtimes\osx\native\liblua54.dylib" />
     <file src="runtimes\linux-x64\native\liblua54.so" target="runtimes\linux-x64\native\liblua54.so" />
+    <file src="runtimes\linux-arm64\native\liblua54.so" target="runtimes\linux-arm64\native\liblua54.so" />
     <file src="runtimes\android-arm\native\liblua54.so" target="runtimes\android-arm\native\liblua54.so" />
     <file src="runtimes\android-arm64\native\liblua54.so" target="runtimes\android-arm64\native\liblua54.so" />
     <file src="runtimes\android-x86\native\liblua54.so" target="runtimes\android-x86\native\liblua54.so" />

--- a/build/targets/BuildLua.Linux.targets
+++ b/build/targets/BuildLua.Linux.targets
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Linux64BuildDir>linux-x64</Linux64BuildDir>
     <LinuxBinaryLibraryPath64>lib64\liblua54.so</LinuxBinaryLibraryPath64>
+    <LinuxArm64BuildDir>linux-arm64</LinuxArm64BuildDir>
   </PropertyGroup>
   <Target Name="BuildLuaLinux" BeforeTargets="BeforeBuild" Condition="'$(OS)'=='Unix' and !Exists('/usr/bin/xcodebuild')">
     <Message Text="Building Linux Lua library (x64)" />
@@ -12,9 +13,18 @@
     <Exec Command="cmake $(ExternalLuaPath) " WorkingDirectory="$(ExternalLuaPath)\$(Linux64BuildDir)" Condition="!Exists('$(ExternalLuaPath)\$(Linux64BuildDir)\CMakeCache.txt')" />
     <Exec Command="cmake --build . --config Release" WorkingDirectory="$(ExternalLuaPath)\$(Linux64BuildDir)" />
     <Copy SourceFiles="$(ExternalLuaPath)\$(Linux64BuildDir)\$(LinuxBinaryLibraryPath64)" DestinationFolder="$(OutputRuntimeDir)\$(Linux64BuildDir)\native" SkipUnchangedFiles="true" />
+
+    <Message Text="Building Linux Lua library (ARM64)" />
+    <Exec Command="export CC=aarch64-linux-gnu-gcc" WorkingDirectory="$(ExternalLuaPath)" Condition="!Exists('$(ExternalLuaPath)\$(LinuxArm64BuildDir)')" />
+    <Exec Command="mkdir $(ExternalLuaPath)\$(LinuxArm64BuildDir)" WorkingDirectory="$(ExternalLuaPath)" Condition="!Exists('$(ExternalLuaPath)\$(LinuxArm64BuildDir)')" />
+    <Exec Command="cmake $(ExternalLuaPath)" WorkingDirectory="$(ExternalLuaPath)\$(LinuxArm64BuildDir)" Condition="!Exists('$(ExternalLuaPath)\$(LinuxArm64BuildDir)\CMakeCache.txt')" />
+    <Exec Command="cmake --build . --config Release" WorkingDirectory="$(ExternalLuaPath)\$(LinuxArm64BuildDir)" />
+    <Copy SourceFiles="$(ExternalLuaPath)\$(LinuxArm64BuildDir)\$(LinuxBinaryLibraryPath64)" DestinationFolder="$(OutputRuntimeDir)\$(LinuxArm64BuildDir)\native" SkipUnchangedFiles="true" />
   </Target>
   <Target Name="CleanLuaLinux" AfterTargets="Clean" Condition="'$(OS)'=='Unix' and !Exists('/usr/bin/xcodebuild')">
       <Message Text="Cleaning Lua library (x64)" />
       <RemoveDir Directories="$(ExternalLuaPath)\$(Linux64BuildDir); $(OutputRuntimeDir)\$(Linux64BuildDir) " />
+      <Message Text="Cleaning Lua library (ARM64)" />
+      <RemoveDir Directories="$(ExternalLuaPath)\$(LinuxArm64BuildDir); $(OutputRuntimeDir)\$(LinuxArm64BuildDir) " />
   </Target>
 </Project>


### PR DESCRIPTION
This PR includes changes on the source side as to make the build support Linux/aarch64 (ARM64). These requires a parallel change on the pipeline side, adding a script task installing the crosscompiler:

sudo apt-get install -qq gcc-aarch64-linux-gnu

* Didn't make this optional, since other builds don't seem to make crossplatform optional.
* Assumes an x86-64 builder like current build does. The equivalent code would install gcc-x86-64-linux-gnu and make an equivalent call to x86_64-linux-gnu-gcc .
